### PR TITLE
Prevent Sysbot loop if Config.IP field is empty

### DIFF
--- a/Discord/Globals.cs
+++ b/Discord/Globals.cs
@@ -10,6 +10,8 @@ namespace SysBot.AnimalCrossing
     {
         public static SysCord Self = default!;
         public static CrossBot Bot = default!;
+
+        public static bool DiscordOnly;
     }
 
     public sealed class RequireQueueRoleAttribute : PreconditionAttribute

--- a/Discord/Modules/ControlModule.cs
+++ b/Discord/Modules/ControlModule.cs
@@ -20,9 +20,14 @@ namespace SysBot.AnimalCrossing
         [Command("setCode")]
         [Summary("Sets a string to the Dodo Code property for users to call via the associated command.")]
         [RequireSudo]
-        public async Task SetDodoCodeAsync([Remainder]string code)
+        public async Task SetDodoCodeAsync([Remainder] string code)
         {
             var bot = Globals.Bot;
+            if (code.Length != 5)
+            {
+                await ReplyAsync("Dodo Code must be 5 characters long.").ConfigureAwait(false);
+                return;
+            }
             bot.DodoCode = code;
             await ReplyAsync($"The dodo code for the bot has been set to {code}.").ConfigureAwait(false);
         }

--- a/Discord/Modules/DropModule.cs
+++ b/Discord/Modules/DropModule.cs
@@ -15,6 +15,11 @@ namespace SysBot.AnimalCrossing
         [Summary("Picks up items around the bot.")]
         public async Task RequestCleanAsync()
         {
+            if (Globals.DiscordOnly)
+            {
+                DiscordOnlyReply();
+                return;
+            }
             if (!Globals.Bot.Config.AllowClean)
             {
                 await ReplyAsync("Clean functionality is currently disabled.").ConfigureAwait(false);
@@ -29,14 +34,24 @@ namespace SysBot.AnimalCrossing
         [Summary("Prints the Dodo Code for the island.")]
         public async Task RequestDodoCodeAsync()
         {
+            if (Globals.DiscordOnly)
+            {
+                DiscordOnlyReply();
+                return;
+            }
             await ReplyAsync($"Dodo Code: {Globals.Bot.DodoCode}.").ConfigureAwait(false);
         }
 
         [Command("dropItem")]
         [Alias("drop")]
         [Summary("Drops a custom item (or items).")]
-        public async Task RequestDropAsync([Remainder]string request)
+        public async Task RequestDropAsync([Remainder] string request)
         {
+            if (Globals.DiscordOnly)
+            {
+                DiscordOnlyReply();
+                return;
+            }
             var split = request.Split(new[] { " ", "\n", "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
             var items = DropUtil.GetItems(split, Globals.Bot.Config);
             await DropItems(items).ConfigureAwait(false);
@@ -45,8 +60,13 @@ namespace SysBot.AnimalCrossing
         [Command("dropDIY")]
         [Alias("diy")]
         [Summary("Drops a DIY recipe with the requested recipe ID(s).")]
-        public async Task RequestDropDIYAsync([Remainder]string recipeIDs)
+        public async Task RequestDropDIYAsync([Remainder] string recipeIDs)
         {
+            if (Globals.DiscordOnly)
+            {
+                DiscordOnlyReply();
+                return;
+            }
             var split = recipeIDs.Split(new[] { " ", "\n", "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
             var items = DropUtil.GetDIYItems(split);
             await DropItems(items).ConfigureAwait(false);
@@ -54,6 +74,7 @@ namespace SysBot.AnimalCrossing
 
         private async Task DropItems(IReadOnlyCollection<Item> items)
         {
+
             const int maxRequestCount = 7;
             if (items.Count > maxRequestCount)
             {
@@ -67,6 +88,10 @@ namespace SysBot.AnimalCrossing
 
             var msg = $"Item drop request{(requestInfo.Items.Count > 1 ? "s" : string.Empty)} will be executed momentarily.";
             await ReplyAsync(msg).ConfigureAwait(false);
+        }
+        public async void DiscordOnlyReply()
+        {
+            await ReplyAsync("This feature is currently disabled as this bot is not connected to a Switch.").ConfigureAwait(false);
         }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -39,28 +39,38 @@ namespace SysBot.AnimalCrossing
             Task.Run(() => sys.MainAsync(config.Token, cancel), cancel);
 #pragma warning restore 4014
 
-            Console.WriteLine("Starting bot loop.");
-            var task = bot.RunAsync(cancel);
-            await task;
-            if (task.IsFaulted)
+            if (config.IP.Length < 1)
             {
-                if (task.Exception == null)
-                {
-                    Console.WriteLine("Bot has terminated due to an unknown error.");
-                }
-                else
-                {
-                    Console.WriteLine("Bot has terminated due to an error:");
-                    foreach (var ex in task.Exception.InnerExceptions)
-                    {
-                        Console.WriteLine(ex.Message);
-                        Console.WriteLine(ex.StackTrace);
-                    }
-                }
+                Console.WriteLine("No IP specified, skipping Sysbot loop.");
+                Globals.DiscordOnly = true;
             }
             else
             {
-                Console.WriteLine("Bot has terminated.");
+                Globals.DiscordOnly = false;
+                Console.WriteLine("Starting bot loop.");
+                var task = bot.RunAsync(cancel);
+                await task;
+
+                if (task.IsFaulted)
+                {
+                    if (task.Exception == null)
+                    {
+                        Console.WriteLine("Bot has terminated due to an unknown error.");
+                    }
+                    else
+                    {
+                        Console.WriteLine("Bot has terminated due to an error:");
+                        foreach (var ex in task.Exception.InnerExceptions)
+                        {
+                            Console.WriteLine(ex.Message);
+                            Console.WriteLine(ex.StackTrace);
+                        }
+                    }
+                }
+                else
+                {
+                    Console.WriteLine("Bot has terminated.");
+                }
             }
 
             Console.WriteLine("Press any key to exit.");
@@ -69,14 +79,14 @@ namespace SysBot.AnimalCrossing
 
         private static void SaveConfig(CrossBotConfig config)
         {
-            var options = new JsonSerializerOptions {WriteIndented = true};
+            var options = new JsonSerializerOptions { WriteIndented = true };
             var json = JsonSerializer.Serialize(config, options);
             File.WriteAllText(ConfigPath, json);
         }
 
         private static void CreateConfigQuit()
         {
-            SaveConfig(new CrossBotConfig {IP = "192.168.0.1", Port = 6000});
+            SaveConfig(new CrossBotConfig { IP = "192.168.0.1", Port = 6000 });
             Console.WriteLine("Created blank config file. Please configure it and restart the program.");
             Console.WriteLine("Press any key to exit.");
             Console.ReadKey();


### PR DESCRIPTION
Allows for easier testing of Discord features that don't require an active connection to a Switch.
Also prevents DropModule commands from promising to be executed when they obviously won't.
Checks DodoCode length, forcing it to be 5, in order to prevent random strings to be entered.