### PR TITLE
Make RoleUseBot restrict based on a Discord role

### DIFF
--- a/Bot/CrossBotConfig.cs
+++ b/Bot/CrossBotConfig.cs
@@ -21,8 +21,8 @@ namespace SysBot.AnimalCrossing
         /// <summary> Bot command prefix. </summary>
         public string Prefix { get; set; } = "$";
 
-        /// <summary> Users with this role are allowed to request custom items. If "@everyone", anyone can request custom items. </summary>
-        public string RoleCustom { get; set; } = "@everyone";
+        /// <summary> Users with this role are allowed to interact with the bot. If "@everyone", anyone can request custom items. </summary>
+        public string RoleUseBot { get; set; } = "@everyone";
 
         // 64bit numbers white-listing certain channels/users for permission
         public List<ulong> Channels { get; set; } = new List<ulong>();
@@ -58,7 +58,7 @@ namespace SysBot.AnimalCrossing
         {
             return roleName switch
             {
-                nameof(RoleCustom) => roles.Contains(RoleCustom),
+                nameof(RoleUseBot) => roles.Contains(RoleUseBot),
                 _ => throw new ArgumentException(nameof(roleName))
             };
         }

--- a/Bot/CrossBotConfig.cs
+++ b/Bot/CrossBotConfig.cs
@@ -21,7 +21,7 @@ namespace SysBot.AnimalCrossing
         /// <summary> Bot command prefix. </summary>
         public string Prefix { get; set; } = "$";
 
-        /// <summary> Users with this role are allowed to interact with the bot. If "@everyone", anyone can request custom items. </summary>
+        /// <summary> Users with this role are allowed to interact with the bot. If "@everyone", anyone can interact. </summary>
         public string RoleUseBot { get; set; } = "@everyone";
 
         // 64bit numbers white-listing certain channels/users for permission

--- a/Bot/CrossBotConfig.cs
+++ b/Bot/CrossBotConfig.cs
@@ -21,8 +21,8 @@ namespace SysBot.AnimalCrossing
         /// <summary> Bot command prefix. </summary>
         public string Prefix { get; set; } = "$";
 
-        /// <summary> Users with this role are allowed to request custom items. If empty, anyone can request custom items. </summary>
-        public string RoleCustom { get; set; } = string.Empty;
+        /// <summary> Users with this role are allowed to request custom items. If "@everyone", anyone can request custom items. </summary>
+        public string RoleCustom { get; set; } = "@everyone";
 
         // 64bit numbers white-listing certain channels/users for permission
         public List<ulong> Channels { get; set; } = new List<ulong>();

--- a/Discord/Modules/DropModule.cs
+++ b/Discord/Modules/DropModule.cs
@@ -12,6 +12,7 @@ namespace SysBot.AnimalCrossing
 
         [Command("clean")]
         [Summary("Picks up items around the bot.")]
+        [RequireQueueRole(nameof(Globals.Bot.Config.RoleCustom))]
         public async Task RequestCleanAsync()
         {
             if (!Globals.Bot.Config.AllowClean)
@@ -26,6 +27,7 @@ namespace SysBot.AnimalCrossing
         [Command("code")]
         [Alias("dodo")]
         [Summary("Prints the Dodo Code for the island.")]
+        [RequireQueueRole(nameof(Globals.Bot.Config.RoleCustom))]
         public async Task RequestDodoCodeAsync()
         {
             await ReplyAsync($"Dodo Code: {Globals.Bot.DodoCode}.").ConfigureAwait(false);
@@ -39,6 +41,7 @@ namespace SysBot.AnimalCrossing
         [Command("dropItem")]
         [Alias("drop")]
         [Summary("Drops a custom item (or items).")]
+        [RequireQueueRole(nameof(Globals.Bot.Config.RoleCustom))]
         public async Task RequestDropAsync([Summary(DropItemSummary)][Remainder]string request)
         {
             var cfg = Globals.Bot.Config;
@@ -54,6 +57,7 @@ namespace SysBot.AnimalCrossing
         [Command("dropDIY")]
         [Alias("diy")]
         [Summary("Drops a DIY recipe with the requested recipe ID(s).")]
+        [RequireQueueRole(nameof(Globals.Bot.Config.RoleCustom))]
         public async Task RequestDropDIYAsync([Summary(DropDIYSummary)][Remainder]string recipeIDs)
         {
             var items = DropUtil.GetDIYsFromUserInput(recipeIDs);

--- a/Discord/Modules/DropModule.cs
+++ b/Discord/Modules/DropModule.cs
@@ -12,7 +12,7 @@ namespace SysBot.AnimalCrossing
 
         [Command("clean")]
         [Summary("Picks up items around the bot.")]
-        [RequireQueueRole(nameof(Globals.Bot.Config.RoleCustom))]
+        [RequireQueueRole(nameof(Globals.Bot.Config.RoleUseBot))]
         public async Task RequestCleanAsync()
         {
             if (!Globals.Bot.Config.AllowClean)
@@ -27,7 +27,7 @@ namespace SysBot.AnimalCrossing
         [Command("code")]
         [Alias("dodo")]
         [Summary("Prints the Dodo Code for the island.")]
-        [RequireQueueRole(nameof(Globals.Bot.Config.RoleCustom))]
+        [RequireQueueRole(nameof(Globals.Bot.Config.RoleUseBot))]
         public async Task RequestDodoCodeAsync()
         {
             await ReplyAsync($"Dodo Code: {Globals.Bot.DodoCode}.").ConfigureAwait(false);
@@ -41,7 +41,7 @@ namespace SysBot.AnimalCrossing
         [Command("dropItem")]
         [Alias("drop")]
         [Summary("Drops a custom item (or items).")]
-        [RequireQueueRole(nameof(Globals.Bot.Config.RoleCustom))]
+        [RequireQueueRole(nameof(Globals.Bot.Config.RoleUseBot))]
         public async Task RequestDropAsync([Summary(DropItemSummary)][Remainder]string request)
         {
             var cfg = Globals.Bot.Config;
@@ -57,7 +57,7 @@ namespace SysBot.AnimalCrossing
         [Command("dropDIY")]
         [Alias("diy")]
         [Summary("Drops a DIY recipe with the requested recipe ID(s).")]
-        [RequireQueueRole(nameof(Globals.Bot.Config.RoleCustom))]
+        [RequireQueueRole(nameof(Globals.Bot.Config.RoleUseBot))]
         public async Task RequestDropDIYAsync([Summary(DropDIYSummary)][Remainder]string recipeIDs)
         {
             var items = DropUtil.GetDIYsFromUserInput(recipeIDs);

--- a/Discord/Modules/ItemModule.cs
+++ b/Discord/Modules/ItemModule.cs
@@ -13,7 +13,7 @@ namespace SysBot.AnimalCrossing
         [Command("lookupLang")]
         [Alias("ll")]
         [Summary("Gets a list of items that contain the request string.")]
-        [RequireQueueRole(nameof(Globals.Bot.Config.RoleCustom))]
+        [RequireQueueRole(nameof(Globals.Bot.Config.RoleUseBot))]
         public async Task SearchItemsAsync([Summary("Language code to search with")] string language, [Summary("Item name / item substring")][Remainder]string itemName)
         {
             var strings = GameInfo.GetStrings(language).ItemDataSource;
@@ -23,7 +23,7 @@ namespace SysBot.AnimalCrossing
         [Command("lookup")]
         [Alias("li", "search")]
         [Summary("Gets a list of items that contain the request string.")]
-        [RequireQueueRole(nameof(Globals.Bot.Config.RoleCustom))]
+        [RequireQueueRole(nameof(Globals.Bot.Config.RoleUseBot))]
         public async Task SearchItemsAsync([Summary("Item name / item substring")][Remainder]string itemName)
         {
             var strings = GameInfo.Strings.ItemDataSource;
@@ -69,7 +69,7 @@ namespace SysBot.AnimalCrossing
 
         [Command("item")]
         [Summary("Gets the info for an item.")]
-        [RequireQueueRole(nameof(Globals.Bot.Config.RoleCustom))]
+        [RequireQueueRole(nameof(Globals.Bot.Config.RoleUseBot))]
         public async Task GetItemInfoAsync([Summary("Item ID (in hex)")]string itemHex)
         {
             ushort itemID = ItemUtil.GetID(itemHex);
@@ -89,7 +89,7 @@ namespace SysBot.AnimalCrossing
 
         [Command("stack")]
         [Summary("Stacks an item and prints the hex code.")]
-        [RequireQueueRole(nameof(Globals.Bot.Config.RoleCustom))]
+        [RequireQueueRole(nameof(Globals.Bot.Config.RoleUseBot))]
         public async Task StackAsync([Summary("Item ID (in hex)")]string itemHex, [Summary("Count of items in the stack")]int count)
         {
             ushort itemID = ItemUtil.GetID(itemHex);
@@ -107,13 +107,13 @@ namespace SysBot.AnimalCrossing
 
         [Command("customize")]
         [Summary("Customizes an item and prints the hex code.")]
-        [RequireQueueRole(nameof(Globals.Bot.Config.RoleCustom))]
+        [RequireQueueRole(nameof(Globals.Bot.Config.RoleUseBot))]
         public async Task CustomizeAsync([Summary("Item ID (in hex)")] string itemHex, [Summary("First customization value")] int cust1, [Summary("Second customization value")] int cust2)
             => await CustomizeAsync(itemHex, cust1 + cust2).ConfigureAwait(false);
 
         [Command("customize")]
         [Summary("Customizes an item and prints the hex code.")]
-        [RequireQueueRole(nameof(Globals.Bot.Config.RoleCustom))]
+        [RequireQueueRole(nameof(Globals.Bot.Config.RoleUseBot))]
         public async Task CustomizeAsync([Summary("Item ID (in hex)")]string itemHex, [Summary("Customization value sum")]int sum)
         {
             ushort itemID = ItemUtil.GetID(itemHex);

--- a/Discord/Modules/ItemModule.cs
+++ b/Discord/Modules/ItemModule.cs
@@ -13,6 +13,7 @@ namespace SysBot.AnimalCrossing
         [Command("lookupLang")]
         [Alias("ll")]
         [Summary("Gets a list of items that contain the request string.")]
+        [RequireQueueRole(nameof(Globals.Bot.Config.RoleCustom))]
         public async Task SearchItemsAsync([Summary("Language code to search with")] string language, [Summary("Item name / item substring")][Remainder]string itemName)
         {
             var strings = GameInfo.GetStrings(language).ItemDataSource;
@@ -22,6 +23,7 @@ namespace SysBot.AnimalCrossing
         [Command("lookup")]
         [Alias("li", "search")]
         [Summary("Gets a list of items that contain the request string.")]
+        [RequireQueueRole(nameof(Globals.Bot.Config.RoleCustom))]
         public async Task SearchItemsAsync([Summary("Item name / item substring")][Remainder]string itemName)
         {
             var strings = GameInfo.Strings.ItemDataSource;
@@ -67,6 +69,7 @@ namespace SysBot.AnimalCrossing
 
         [Command("item")]
         [Summary("Gets the info for an item.")]
+        [RequireQueueRole(nameof(Globals.Bot.Config.RoleCustom))]
         public async Task GetItemInfoAsync([Summary("Item ID (in hex)")]string itemHex)
         {
             ushort itemID = ItemUtil.GetID(itemHex);
@@ -86,6 +89,7 @@ namespace SysBot.AnimalCrossing
 
         [Command("stack")]
         [Summary("Stacks an item and prints the hex code.")]
+        [RequireQueueRole(nameof(Globals.Bot.Config.RoleCustom))]
         public async Task StackAsync([Summary("Item ID (in hex)")]string itemHex, [Summary("Count of items in the stack")]int count)
         {
             ushort itemID = ItemUtil.GetID(itemHex);
@@ -103,11 +107,13 @@ namespace SysBot.AnimalCrossing
 
         [Command("customize")]
         [Summary("Customizes an item and prints the hex code.")]
+        [RequireQueueRole(nameof(Globals.Bot.Config.RoleCustom))]
         public async Task CustomizeAsync([Summary("Item ID (in hex)")] string itemHex, [Summary("First customization value")] int cust1, [Summary("Second customization value")] int cust2)
             => await CustomizeAsync(itemHex, cust1 + cust2).ConfigureAwait(false);
 
         [Command("customize")]
         [Summary("Customizes an item and prints the hex code.")]
+        [RequireQueueRole(nameof(Globals.Bot.Config.RoleCustom))]
         public async Task CustomizeAsync([Summary("Item ID (in hex)")]string itemHex, [Summary("Customization value sum")]int sum)
         {
             ushort itemID = ItemUtil.GetID(itemHex);

--- a/Discord/Modules/RecipeModule.cs
+++ b/Discord/Modules/RecipeModule.cs
@@ -13,6 +13,7 @@ namespace SysBot.AnimalCrossing
         [Command("recipeLang")]
         [Alias("rl")]
         [Summary("Gets a list of DIY recipe IDs that contain the requested Item Name string.")]
+        [RequireQueueRole(nameof(Globals.Bot.Config.RoleCustom))]
         public async Task SearchItemsAsync([Summary("Language code to search with")] string language, [Summary("Item name / item substring")][Remainder] string itemName)
         {
             var strings = GameInfo.GetStrings(language).ItemDataSource;
@@ -22,6 +23,7 @@ namespace SysBot.AnimalCrossing
         [Command("recipe")]
         [Alias("ri", "searchDIY")]
         [Summary("Gets a list of DIY recipe IDs that contain the requested Item Name string.")]
+        [RequireQueueRole(nameof(Globals.Bot.Config.RoleCustom))]
         public async Task SearchItemsAsync([Summary("Item name / item substring")][Remainder] string itemName)
         {
             var strings = GameInfo.Strings.ItemDataSource;

--- a/Discord/Modules/RecipeModule.cs
+++ b/Discord/Modules/RecipeModule.cs
@@ -13,7 +13,7 @@ namespace SysBot.AnimalCrossing
         [Command("recipeLang")]
         [Alias("rl")]
         [Summary("Gets a list of DIY recipe IDs that contain the requested Item Name string.")]
-        [RequireQueueRole(nameof(Globals.Bot.Config.RoleCustom))]
+        [RequireQueueRole(nameof(Globals.Bot.Config.RoleUseBot))]
         public async Task SearchItemsAsync([Summary("Language code to search with")] string language, [Summary("Item name / item substring")][Remainder] string itemName)
         {
             var strings = GameInfo.GetStrings(language).ItemDataSource;
@@ -23,7 +23,7 @@ namespace SysBot.AnimalCrossing
         [Command("recipe")]
         [Alias("ri", "searchDIY")]
         [Summary("Gets a list of DIY recipe IDs that contain the requested Item Name string.")]
-        [RequireQueueRole(nameof(Globals.Bot.Config.RoleCustom))]
+        [RequireQueueRole(nameof(Globals.Bot.Config.RoleUseBot))]
         public async Task SearchItemsAsync([Summary("Item name / item substring")][Remainder] string itemName)
         {
             var strings = GameInfo.Strings.ItemDataSource;


### PR DESCRIPTION
Seems you need ``@everyone`` by default; leaving it blank makes everyone unable to use it.