### PR TITLE
Fix typo

### DIFF
--- a/CrossBot.Discord/Discord/Modules/IslandModule.cs
+++ b/CrossBot.Discord/Discord/Modules/IslandModule.cs
@@ -55,7 +55,7 @@ namespace CrossBot.Discord
             var island = Globals.Bot.Island;
             if (cfg.RequireJoin && island.Count >= cfg.MaxVisitorCount && !Globals.Self.Config.CanUseSudo(user.Id))
             {
-                await ReplyAsync($"Too many people are already on the island (max {cfg.MaxVisitorCount}. Please wait until someone leaves.").ConfigureAwait(false);
+                await ReplyAsync($"Too many people are already on the island (max {cfg.MaxVisitorCount}). Please wait until someone leaves.").ConfigureAwait(false);
                 return;
             }
 


### PR DESCRIPTION
Close brackets properly in string return for `$join` when island is full.